### PR TITLE
Fix typo in deploy pipeline's trigger event type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   pull_request:
-    type: [closed]
+    types: [closed]
     branches: develop
   workflow_dispatch:
 


### PR DESCRIPTION
Making header's logo smaller cuts almost half of it. Logo is loaded via Angular Material MatIcon's logic, so most of control over logo's behavior is not accessible from styles. This is not a big change, so leaving it as is.

Fix of type in pipeline should repair it, so from now on all PRs should trigger deploy to test env after merge properly.